### PR TITLE
Fix audio entitlement when PipeWire runs as a user service

### DIFF
--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -278,17 +278,59 @@ func applyAudio(spec *Spec) {
 		Access: "rwm",
 	})
 
-	// Mount PipeWire socket if available.
-	spec.Mounts = append(spec.Mounts, Mount{
-		Destination: "/run/pipewire",
-		Source:      "/run/pipewire",
-		Type:        "bind",
-		Options:     []string{"rbind", "nosuid", "noexec"},
-	})
+	// isSocket reports whether path is a Unix domain socket. Uses Lstat
+	// so symlinks are not followed — runc can't resolve symlink targets
+	// through bind mounts.
+	isSocket := func(path string) bool {
+		fi, err := os.Lstat(path)
+		return err == nil && fi.Mode()&os.ModeSocket != 0 && fi.Mode()&os.ModeSymlink == 0
+	}
 
-	spec.Process.Env = append(spec.Process.Env,
-		"PIPEWIRE_RUNTIME_DIR=/run/pipewire",
-	)
+	// Find the PipeWire socket. Check the system path first, then probe
+	// for a user session socket (e.g. /run/user/1000/pipewire-0 on RPi OS
+	// where PipeWire runs as a user service).
+	var pipewireSocketSource string
+	if isSocket("/run/pipewire/pipewire-0") {
+		pipewireSocketSource = "/run/pipewire/pipewire-0"
+	} else {
+		userSockets, _ := filepath.Glob("/run/user/*/pipewire-0")
+		for _, s := range userSockets {
+			if isSocket(s) {
+				pipewireSocketSource = s
+				break
+			}
+		}
+	}
+
+	if pipewireSocketSource != "" {
+		// Mount the individual socket file into the container.
+		spec.Mounts = append(spec.Mounts, Mount{
+			Destination: "/run/pipewire/pipewire-0",
+			Source:      pipewireSocketSource,
+			Type:        "bind",
+			Options:     []string{"rbind", "nosuid", "noexec"},
+		})
+		spec.Process.Env = append(spec.Process.Env,
+			"PIPEWIRE_RUNTIME_DIR=/run/pipewire",
+		)
+
+		// Check for PulseAudio compat socket in the same source directory.
+		// PipeWire provides a PulseAudio emulation socket that GStreamer's
+		// autoaudiosink needs (pulsesink has the highest rank).
+		sourceDir := filepath.Dir(pipewireSocketSource)
+		pulseNative := filepath.Join(sourceDir, "pulse", "native")
+		if isSocket(pulseNative) {
+			spec.Mounts = append(spec.Mounts, Mount{
+				Destination: "/run/pipewire/pulse-native",
+				Source:      pulseNative,
+				Type:        "bind",
+				Options:     []string{"rbind", "nosuid", "noexec"},
+			})
+			spec.Process.Env = append(spec.Process.Env,
+				"PULSE_SERVER=unix:/run/pipewire/pulse-native",
+			)
+		}
+	}
 }
 
 // applyVideo adds video device access.

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -3,6 +3,7 @@ package oci
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -184,13 +185,48 @@ func TestApplyEntitlements_Audio(t *testing.T) {
 		t.Error("audio entitlement did not add /dev/snd mount")
 	}
 
-	// Should mount PipeWire socket.
-	if !hasMountDest(spec, "/run/pipewire") {
-		t.Error("audio entitlement did not add /run/pipewire mount")
+	// PipeWire mount is conditional — only added when a real socket exists
+	// on the host at either /run/pipewire/pipewire-0 (system) or
+	// /run/user/*/pipewire-0 (user session).
+	isSocket := func(path string) bool {
+		fi, err := os.Lstat(path)
+		return err == nil && fi.Mode()&os.ModeSocket != 0 && fi.Mode()&os.ModeSymlink == 0
 	}
-
-	if !hasEnv(spec, "PIPEWIRE_RUNTIME_DIR") {
-		t.Error("audio entitlement did not set PIPEWIRE_RUNTIME_DIR")
+	// Mirror applyAudio's socket detection: system path first, then user session.
+	var pipewireSocketSource string
+	if isSocket("/run/pipewire/pipewire-0") {
+		pipewireSocketSource = "/run/pipewire/pipewire-0"
+	} else {
+		userSockets, _ := filepath.Glob("/run/user/*/pipewire-0")
+		for _, s := range userSockets {
+			if isSocket(s) {
+				pipewireSocketSource = s
+				break
+			}
+		}
+	}
+	if pipewireSocketSource != "" {
+		if !hasMountDest(spec, "/run/pipewire/pipewire-0") {
+			t.Error("audio entitlement did not add /run/pipewire/pipewire-0 mount")
+		}
+		if !hasEnv(spec, "PIPEWIRE_RUNTIME_DIR") {
+			t.Error("audio entitlement did not set PIPEWIRE_RUNTIME_DIR")
+		}
+		// Derive pulse path from the same source directory as applyAudio does.
+		sourceDir := filepath.Dir(pipewireSocketSource)
+		pulseNative := filepath.Join(sourceDir, "pulse", "native")
+		if isSocket(pulseNative) {
+			if !hasMountDest(spec, "/run/pipewire/pulse-native") {
+				t.Error("audio entitlement did not add /run/pipewire/pulse-native mount")
+			}
+			if !hasEnv(spec, "PULSE_SERVER") {
+				t.Error("audio entitlement did not set PULSE_SERVER when pulse socket exists")
+			}
+		}
+	} else {
+		if hasMountDest(spec, "/run/pipewire/pipewire-0") || hasMountDest(spec, "/run/pipewire/pulse-native") {
+			t.Error("audio entitlement should not mount /run/pipewire when socket is absent")
+		}
 	}
 }
 


### PR DESCRIPTION
Backport of wendylabsinc/wendy-agent#459 for local testing.

Detect PipeWire and PulseAudio sockets at both system and user-session paths, validate with Lstat + ModeSocket, and mount directly into the container via OCI spec file-level bind mounts.